### PR TITLE
fix: 解决 CJK 标点相邻时粗体/斜体渲染失败的问题

### DIFF
--- a/scripts/cjk-bold-fix.js
+++ b/scripts/cjk-bold-fix.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const WJ = '\u2060';
+
+hexo.extend.filter.register('before_post_render', function(data) {
+  data.content = data.content.replace(
+    /(```[\s\S]*?```|`[^`]*`)|([\u3000-\u303f\uff00-\uffef])(\*+)(?=[^\s*])|(\*+)([\u3000-\u303f\uff00-\uffef])/g,
+    (match, code, punct, stars, stars2, punct2) => {
+      if (code) return code;
+      if (punct && stars) return punct + WJ + stars;
+      if (stars2 && punct2) return stars2 + WJ + punct2;
+      return match;
+    }
+  );
+  return data;
+});
+
+hexo.extend.filter.register('after_post_render', function(data) {
+  data.content = data.content.replace(/\u2060/g, '');
+  return data;
+});


### PR DESCRIPTION
When the bold/italic */ character is adjacent to a CJK punctuation mark (such as , or .) ：！ ？ When this occurs, due to the CommonMark left and right wing determination rules, the markup parser is unable to recognize ** as a valid delimiter, resulting in ** being rendered as regular text. 
By inserting a zero-width Word Joiner (U+2060) between CJK punctuation and * delimiters, the character classification is changed, allowing ** to be restored as a valid delimiter. After rendering, this character is removed.